### PR TITLE
Update mongodb.rb

### DIFF
--- a/lib/logstash/inputs/mongodb.rb
+++ b/lib/logstash/inputs/mongodb.rb
@@ -326,8 +326,18 @@ class LogStash::Inputs::MongoDB < LogStash::Inputs::Base
                   end
                 end
               end
-            else
-              # Should probably do some sanitization here and insert the doc as raw as possible for parsing in logstash
+            elsif @parse_method == 'simple'
+              doc.each do |k, v|
+                  if v.is_a? Numeric
+                    event[k] = v.abs
+                  elsif v.is_a? Array
+                    event[k] = v
+                  elsif v == "NaN"
+                    event[k] = Float::NAN
+                  else
+                    event[k] = v.to_s
+                  end
+              end
             end
 
             queue << event


### PR DESCRIPTION
I wanted to keep my mongo docs structure which includes arrays & nested objects but both flatten nor dig allowed me to do it properly so I created a new simple method.
I added parse_method == 'simple' which format numbers (int & float supported), keep arrays format (as array instead of string with flatten or dig methods), check for null, support string fields.
If you think it will be usable for other people (I do, since before writing it I tried almost any possible config which didn't work) add it to master.