### PR TITLE
Add mongo authentication and update the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ batch_size           [Int]         Size of the batch of mongo documents to pull 
 parse_method         [String]      Built in parsing of the mongodb document object [Default: 'flatten']
 dig_fields           [Array]       An array of fields that should employ the dig method
 dig_dig_fields       [Array]       This provides a second level of hash flattening after the initial dig has been done
+user                 [String]      The username to use, in case the MongoDB deployment enforces authentication [Not required]
+password             [String]      The password to use, in case the MongoDB deployment enforces authentication [Not required]
+use_ssl              [Boolean]     If true, ssl authentication will be used [Default: false]
 ```
 
 

--- a/lib/logstash/inputs/mongodb.rb
+++ b/lib/logstash/inputs/mongodb.rb
@@ -73,6 +73,17 @@ class LogStash::Inputs::MongoDB < LogStash::Inputs::Base
   # The default, `1`, means send a message every second.
   config :interval, :validate => :number, :default => 1
 
+  # The user to use, in case mongo authentication is enabled.
+  # The default means that no authentication will be used.
+  config :user, :validate => :string, :default => "Default user..."
+
+  # The password to use, in case mongo authentication is enabled.
+  config :password, :validate => :string, :default => "Default password..."
+
+  # Whether to use ssl when connecting to the mongoDB.
+  # The default, means that ssl will not be used.
+  config :use_ssl, :validate => :boolean, :default => false
+
   SINCE_TABLE = :since_table
 
   public
@@ -170,7 +181,13 @@ class LogStash::Inputs::MongoDB < LogStash::Inputs::Base
     require "jdbc/sqlite3"
     require "sequel"
     placeholder_db_path = File.join(@placeholder_db_dir, @placeholder_db_name)
-    conn = Mongo::Client.new(@uri)
+    
+    # In case the default user hasn't been changed, do not use authentication 
+    if (user == "Default user...")
+    	conn = Mongo::Client.new(@uri)
+    else 
+    	conn = Mongo::Client.new(@uri, :user => @user, :password => @password, :ssl => @use_ssl)
+    end
 
     @host = Socket.gethostname
     @logger.info("Registering MongoDB input")


### PR DESCRIPTION
Add the ability to configure user and password that will be used in case a mongo authentication is enabled.
In case a user name was not configured, connection to the mongoDB will be created without special permissions 