### PR TITLE
Add a new parsing method: 'json' store the original mongo document in…

### DIFF
--- a/lib/logstash/inputs/mongodb.rb
+++ b/lib/logstash/inputs/mongodb.rb
@@ -354,6 +354,9 @@ class LogStash::Inputs::MongoDB < LogStash::Inputs::Base
                     event.set(k, v.to_s)
                   end
               end
+
+            elsif @parse_method == 'json'
+              event.set('data', doc.to_json)
             end
 
             queue << event


### PR DESCRIPTION
Add a new parsing method: 'json' store the original mongo document in to the event 'data' props
Exemple:
`input { 
  mongodb {
    uri => ''
    collection => 'mycollection'
    parse_method => 'json'
    generateId => true
  }
}
filter {
  json {
      source => "data"
  }`